### PR TITLE
Correctly pass agents to follow-redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Fixes and Functionallity:
 - Add error toJSON example (#2466)[https://github.com/axios/axios/pull/2466]
 - Fixing Vulnerability A Fortify Scan finds a critical Cross-Site Scrip… (#2451)[https://github.com/axios/axios/pull/2451]
 - Fixing subdomain handling on no_proxy (#2442)[https://github.com/axios/axios/pull/2442]
-- Make redirection from HTTP to HTTPS work (#2426)[https://github.com/axios/axios/pull/2426]
+- Make redirection from HTTP to HTTPS work (#2426)[https://github.com/axios/axios/pull/2426] and (#2547)[https://github.com/axios/axios/pull/2547]
 - Add toJSON property to AxiosError type (#2427)[https://github.com/axios/axios/pull/2427]
 - Fixing socket hang up error on node side for slow response. (#1752)[https://github.com/axios/axios/pull/1752]
 - Alternative syntax to send data into the body (#2317)[https://github.com/axios/axios/pull/2317]

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -86,8 +86,8 @@ module.exports = function httpAdapter(config) {
       headers: headers,
       agent: agent,
       agents: {
-        httpsAgent: config.httpsAgent,
-        httpAgent: config.httpAgent
+        https: config.httpsAgent,
+        http: config.httpAgent
       },
       auth: auth
     };


### PR DESCRIPTION
This fixes #2546. Moving https://github.com/axios/axios/pull/2547 here.